### PR TITLE
Hotfix  hande param values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to the `robotiq_hande_driver` package will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+* [PR-1](https://github.com/AGH-CEAI/robotiq_hande_description/pull/1) - Configuration parameters for ModbusRTU
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security

--- a/urdf/robotiq_hande_gripper.ros2_control.xacro
+++ b/urdf/robotiq_hande_gripper.ros2_control.xacro
@@ -9,15 +9,15 @@
 
         <xacro:unless value="${use_fake_hardware}">
           <plugin>robotiq_hande_driver/RobotiqHandeHardwareInterface</plugin>
+          <param name="grip_pos_min">${grip_pos_min}</param>
+          <param name="grip_pos_max">${grip_pos_max}</param>
+          <param name="tty">${tty}</param>
+          <param name="baudrate">${baudrate}</param>
+          <param name="parity">${parity}</param>
+          <param name="data_bits">${data_bits}</param>
+          <param name="stop_bit">${stop_bit}</param>
+          <param name="slave_id">${slave_id}</param>
         </xacro:unless>
-        <param name="grip_pos_min">${grip_pos_min}</param>
-        <param name="grip_pos_max">${grip_pos_max}</param>
-        <param name="tty">${tty}</param>
-        <param name="baudrate">${baudrate}</param>
-        <param name="parity">${parity}</param>
-        <param name="data_bits">${data_bits}</param>
-        <param name="stop_bit">${stop_bit}</param>
-        <param name="slave_id">${slave_id}</param>
       </hardware>
 
       <!-- The right finger joint uses the mimic feature -->

--- a/urdf/robotiq_hande_gripper.ros2_control.xacro
+++ b/urdf/robotiq_hande_gripper.ros2_control.xacro
@@ -9,14 +9,14 @@
 
         <xacro:unless value="${use_fake_hardware}">
           <plugin>robotiq_hande_driver/RobotiqHandeHardwareInterface</plugin>
-          <param name="grip_pos_min">${grip_pos_min}</param>
-          <param name="grip_pos_max">${grip_pos_max}</param>
-          <param name="tty">${tty}</param>
-          <param name="baudrate">${baudrate}</param>
-          <param name="parity">${parity}</param>
-          <param name="data_bits">${data_bits}</param>
-          <param name="stop_bit">${stop_bit}</param>
-          <param name="slave_id">${slave_id}</param>
+          <param name="grip_pos_min">"${grip_pos_min}"</param>
+          <param name="grip_pos_max">"${grip_pos_max}"</param>
+          <param name="tty">"${tty}"</param>
+          <param name="baudrate">"${baudrate}"</param>
+          <param name="parity">"${parity}"</param>
+          <param name="data_bits">"${data_bits}"</param>
+          <param name="stop_bit">"${stop_bit}"</param>
+          <param name="slave_id">"${slave_id}"</param>
         </xacro:unless>
       </hardware>
 

--- a/urdf/robotiq_hande_gripper.ros2_control.xacro
+++ b/urdf/robotiq_hande_gripper.ros2_control.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <xacro:macro name="robotiq_hande_ros2_control" params="name prefix tty use_fake_hardware:=false">
+  <xacro:macro name="robotiq_hande_ros2_control" params="name prefix grip_pos_min grip_pos_max tty baudrate parity data_bits stop_bit slave_id use_fake_hardware:=false">
     <ros2_control name="${name}" type="system">
       <hardware>
         <xacro:if value="${use_fake_hardware}">
@@ -9,7 +9,14 @@
 
         <xacro:unless value="${use_fake_hardware}">
           <plugin>robotiq_hande_driver/RobotiqHandeHardwareInterface</plugin>
+          <param name="grip_pos_min">${grip_pos_min}</param>
+          <param name="grip_pos_max">${grip_pos_max}</param>
           <param name="tty">${tty}</param>
+          <param name="baudrate">${baudrate}</param>
+          <param name="parity">${parity}</param>
+          <param name="data_bits">${data_bits}</param>
+          <param name="stop_bit">${stop_bit}</param>
+          <param name="slave_id">${slave_id}</param>
         </xacro:unless>
       </hardware>
 

--- a/urdf/robotiq_hande_gripper.ros2_control.xacro
+++ b/urdf/robotiq_hande_gripper.ros2_control.xacro
@@ -9,14 +9,14 @@
 
         <xacro:unless value="${use_fake_hardware}">
           <plugin>robotiq_hande_driver/RobotiqHandeHardwareInterface</plugin>
-          <param name="grip_pos_min">"${grip_pos_min}"</param>
-          <param name="grip_pos_max">"${grip_pos_max}"</param>
-          <param name="tty">"${tty}"</param>
-          <param name="baudrate">"${baudrate}"</param>
-          <param name="parity">"${parity}"</param>
-          <param name="data_bits">"${data_bits}"</param>
-          <param name="stop_bit">"${stop_bit}"</param>
-          <param name="slave_id">"${slave_id}"</param>
+          <param name="grip_pos_min">${grip_pos_min}</param>
+          <param name="grip_pos_max">${grip_pos_max}</param>
+          <param name="tty">${tty}</param>
+          <param name="baudrate">${baudrate}</param>
+          <param name="parity">${parity}</param>
+          <param name="data_bits">${data_bits}</param>
+          <param name="stop_bit">${stop_bit}</param>
+          <param name="slave_id">${slave_id}</param>
         </xacro:unless>
       </hardware>
 

--- a/urdf/robotiq_hande_gripper.ros2_control.xacro
+++ b/urdf/robotiq_hande_gripper.ros2_control.xacro
@@ -9,15 +9,15 @@
 
         <xacro:unless value="${use_fake_hardware}">
           <plugin>robotiq_hande_driver/RobotiqHandeHardwareInterface</plugin>
-          <param name="grip_pos_min">${grip_pos_min}</param>
-          <param name="grip_pos_max">${grip_pos_max}</param>
-          <param name="tty">${tty}</param>
-          <param name="baudrate">${baudrate}</param>
-          <param name="parity">${parity}</param>
-          <param name="data_bits">${data_bits}</param>
-          <param name="stop_bit">${stop_bit}</param>
-          <param name="slave_id">${slave_id}</param>
         </xacro:unless>
+        <param name="grip_pos_min">${grip_pos_min}</param>
+        <param name="grip_pos_max">${grip_pos_max}</param>
+        <param name="tty">${tty}</param>
+        <param name="baudrate">${baudrate}</param>
+        <param name="parity">${parity}</param>
+        <param name="data_bits">${data_bits}</param>
+        <param name="stop_bit">${stop_bit}</param>
+        <param name="slave_id">${slave_id}</param>
       </hardware>
 
       <!-- The right finger joint uses the mimic feature -->
@@ -30,6 +30,7 @@
           <param name="initial_value">0.025</param>
         </state_interface>
         <state_interface name="velocity"/>
+          <param name="initial_value">0</param>
       </joint>
     </ros2_control>
   </xacro:macro>

--- a/urdf/robotiq_hande_gripper.ros2_control.xacro
+++ b/urdf/robotiq_hande_gripper.ros2_control.xacro
@@ -29,8 +29,9 @@
         <state_interface name="position">
           <param name="initial_value">0.025</param>
         </state_interface>
-        <state_interface name="velocity"/>
+        <state_interface name="velocity">
           <param name="initial_value">0</param>
+        </state_interface>
       </joint>
     </ros2_control>
   </xacro:macro>

--- a/urdf/robotiq_hande_gripper.urdf.xacro
+++ b/urdf/robotiq_hande_gripper.urdf.xacro
@@ -26,6 +26,6 @@
     data_bits="$(arg data_bits)"
     stop_bit="$(arg stop_bit)"
     slave_id="$(arg slave_id)"
-    use_fake_hardware="${mock_hardware}"
+    use_fake_hardware="$(use_fake_hardware)"
   />
 </robot>

--- a/urdf/robotiq_hande_gripper.urdf.xacro
+++ b/urdf/robotiq_hande_gripper.urdf.xacro
@@ -1,11 +1,18 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro" name="robotiq_hande_gripper">
   <xacro:arg name="parent" default="tool0"/>
-  <xacro:arg name="tty" default="/dev/ttyXXX"/>
+  <xacro:arg name="grip_pos_min" default="0.0"/>
+  <xacro:arg name="grip_pos_max" default="0.025"/>
+  <xacro:arg name="tty" default="/dev/ttyUR"/>
+  <xacro:arg name="baudrate" default="115200"/>
+  <xacro:arg name="parity" default="N"/>
+  <xacro:arg name="data_bits" default="8"/>
+  <xacro:arg name="stop_bit" default="1"/>
+  <xacro:arg name="slave_id" default="9"/>
   <xacro:arg name="use_fake_hardware" default="true"/>
 
   <xacro:include filename="$(find robotiq_hande_description)/urdf/robotiq_hande_gripper.xacro"/>
 
   <link name="$(arg parent)"/>
-  <xacro:robotiq_hande_gripper name="robotiq_hande_gripper" prefix="" parent="$(arg parent)" tty="$(arg tty)" use_fake_hardware="$(arg use_fake_hardware)"/>
+  <xacro:robotiq_hande_gripper name="robotiq_hande_gripper" prefix="" parent="$(arg parent)" grip_pos_min="$(arg grip_pos_min)" grip_pos_max="$(arg grip_pos_max)" tty="$(arg tty)" baudrate="$(arg baudrate)" parity="$(arg parity)" data_bits="$(arg data_bits)" stop_bit="$(arg stop_bit)" slave_id="$(arg slave_id)" use_fake_hardware="${mock_hardware}"/>
 </robot>

--- a/urdf/robotiq_hande_gripper.urdf.xacro
+++ b/urdf/robotiq_hande_gripper.urdf.xacro
@@ -3,7 +3,7 @@
   <xacro:arg name="parent" default="tool0"/>
   <xacro:arg name="grip_pos_min" default="0"/>
   <xacro:arg name="grip_pos_max" default="0.025"/>
-  <xacro:arg name="tty" default="/dev/ttyUR"/>
+  <xacro:arg name="tty" default="/tmp/ttyUR"/>
   <xacro:arg name="baudrate" default="115200"/>
   <xacro:arg name="parity" default="N"/>
   <xacro:arg name="data_bits" default="8"/>

--- a/urdf/robotiq_hande_gripper.urdf.xacro
+++ b/urdf/robotiq_hande_gripper.urdf.xacro
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro" name="robotiq_hande_gripper">
   <xacro:arg name="parent" default="tool0"/>
-  <xacro:arg name="grip_pos_min" default="0.0"/>
+  <xacro:arg name="grip_pos_min" default="0"/>
   <xacro:arg name="grip_pos_max" default="0.025"/>
   <xacro:arg name="tty" default="/dev/ttyUR"/>
   <xacro:arg name="baudrate" default="115200"/>
@@ -14,5 +14,18 @@
   <xacro:include filename="$(find robotiq_hande_description)/urdf/robotiq_hande_gripper.xacro"/>
 
   <link name="$(arg parent)"/>
-  <xacro:robotiq_hande_gripper name="robotiq_hande_gripper" prefix="" parent="$(arg parent)" grip_pos_min="$(arg grip_pos_min)" grip_pos_max="$(arg grip_pos_max)" tty="$(arg tty)" baudrate="$(arg baudrate)" parity="$(arg parity)" data_bits="$(arg data_bits)" stop_bit="$(arg stop_bit)" slave_id="$(arg slave_id)" use_fake_hardware="${mock_hardware}"/>
+  <xacro:robotiq_hande_gripper
+    name="robotiq_hande_gripper"
+    prefix=""
+    parent="$(arg parent)"
+    grip_pos_min="$(arg grip_pos_min)"
+    grip_pos_max="$(arg grip_pos_max)"
+    tty="$(arg tty)"
+    baudrate="$(arg baudrate)"
+    parity="$(arg parity)"
+    data_bits="$(arg data_bits)"
+    stop_bit="$(arg stop_bit)"
+    slave_id="$(arg slave_id)"
+    use_fake_hardware="${mock_hardware}"
+  />
 </robot>

--- a/urdf/robotiq_hande_gripper.xacro
+++ b/urdf/robotiq_hande_gripper.xacro
@@ -7,9 +7,9 @@
   <xacro:include filename="$(find robotiq_hande_description)/urdf/materials.xacro"/>
   <xacro:include filename="$(find robotiq_hande_description)/urdf/robotiq_hande_gripper.ros2_control.xacro"/>
 
-  <xacro:macro name="robotiq_hande_gripper" params="name prefix parent tty use_fake_hardware">
+  <xacro:macro name="robotiq_hande_gripper" params="name prefix parent grip_pos_min grip_pos_max tty baudrate parity data_bits stop_bit slave_id use_fake_hardware">
     <!-- ros2_control parameters  -->
-    <xacro:robotiq_hande_ros2_control name="${name}" prefix="${prefix}" tty="${tty}" use_fake_hardware="${use_fake_hardware}"/>
+    <xacro:robotiq_hande_ros2_control name="${name}" prefix="${prefix}" grip_pos_min="${grip_pos_min}" grip_pos_max="${grip_pos_max}" tty="${tty}" baudrate="${baudrate}" parity="${parity}" data_bits="${data_bits}" stop_bit="${stop_bit}" slave_id="${slave_id}" use_fake_hardware="${use_fake_hardware}"/>
 
     <!-- Robotiq Coupler -->
     <!--  + Height added by the coupler (13.9mm) -->

--- a/urdf/robotiq_hande_gripper.xacro
+++ b/urdf/robotiq_hande_gripper.xacro
@@ -9,7 +9,19 @@
 
   <xacro:macro name="robotiq_hande_gripper" params="name prefix parent grip_pos_min grip_pos_max tty baudrate parity data_bits stop_bit slave_id use_fake_hardware">
     <!-- ros2_control parameters  -->
-    <xacro:robotiq_hande_ros2_control name="${name}" prefix="${prefix}" grip_pos_min="${grip_pos_min}" grip_pos_max="${grip_pos_max}" tty="${tty}" baudrate="${baudrate}" parity="${parity}" data_bits="${data_bits}" stop_bit="${stop_bit}" slave_id="${slave_id}" use_fake_hardware="${use_fake_hardware}"/>
+    <xacro:robotiq_hande_ros2_control
+      name="${name}"
+      prefix="${prefix}"
+      grip_pos_min="${grip_pos_min}"
+      grip_pos_max="${grip_pos_max}"
+      tty="${tty}"
+      baudrate="${baudrate}"
+      parity="${parity}"
+      data_bits="${data_bits}"
+      stop_bit="${stop_bit}"
+      slave_id="${slave_id}"
+      use_fake_hardware="${use_fake_hardware}"
+    />
 
     <!-- Robotiq Coupler -->
     <!--  + Height added by the coupler (13.9mm) -->


### PR DESCRIPTION
## Description
We need parameters parsed as strings, not strings in quotation marks.

## Motivation and context
Libs have problems with parsing values to double or int.

## How has this been tested?
Building a project.


## Checklist
- [ ] All TODOs in the code have been resolved or linked to a proper issue.
- [ ] Code has been (auto)formatted.
- [ ] Documentation (e.g., README, CHANGELOG, Wiki) has been updated.
- [ ] All automated checks have passed.

---
Clickup task: [869619b4u](https://app.clickup.com/t/869619b4u)
