### PR TITLE
Fix typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+
+* [PR-14](https://github.com/AGH-CEAI/robotiq_hande_description/pull/14) - Adds new parameters for the ros2_control: `frequency_hz`, `create_socat_tty`, `ip_adress` and `port`.
+
 ### Changed
 ### Deprecated
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [PR-14](https://github.com/AGH-CEAI/robotiq_hande_description/pull/14) - Adds new parameters for the ros2_control: `frequency_hz`, `create_socat_tty`, `ip_adress` and `port`.
 
 ### Changed
+
+* [PR-14](https://github.com/AGH-CEAI/robotiq_hande_description/pull/14) - Updated CMake version from `3.8` to `3.16`; changed ros2_control param name `tty` to `tty_port`.
+
+
 ### Deprecated
 ### Removed
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* [PR-14](https://github.com/AGH-CEAI/robotiq_hande_description/pull/14) - Adds new parameters for the ros2_control: `frequency_hz`, `create_socat_tty`, `ip_adress` and `port`.
+* [PR-14](https://github.com/AGH-CEAI/robotiq_hande_description/pull/14) - Adds new parameters for the ros2_control: `frequency_hz`, `create_socat_tty`, `ip_address` and `port`.
 
 ### Changed
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.16)
 project(robotiq_hande_description)
 
 find_package(ament_cmake REQUIRED)

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ For estabilishg a connection with [robotiq_hande_driver](https://github.com/AGH-
     parent="tool0"
     grip_pos_min="0.0"
     grip_pos_max="0.025"
-    tty="/tmp/ttyUR"
+    tty_port="/tmp/ttyUR"
     baudrate="115200"
     parity="N"
     data_bits="8"

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ For estabilishg a connection with [robotiq_hande_driver](https://github.com/AGH-
     data_bits="8"
     stop_bit="1"
     slave_id="9"
+    frequency_hz="10"
     use_fake_hardware="false"
   />
 ```

--- a/urdf/robotiq_hande_gripper.ros2_control.xacro
+++ b/urdf/robotiq_hande_gripper.ros2_control.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <xacro:macro name="robotiq_hande_ros2_control" params="name prefix grip_pos_min grip_pos_max tty_port baudrate parity data_bits stop_bit slave_id frequency_hz use_fake_hardware">
+  <xacro:macro name="robotiq_hande_ros2_control" params="name prefix grip_pos_min grip_pos_max tty_port baudrate parity data_bits stop_bit slave_id frequency_hz create_socat_tty ip_adress port use_fake_hardware">
     <ros2_control name="${name}" type="system">
       <hardware>
         <xacro:if value="${use_fake_hardware}">
@@ -11,6 +11,7 @@
           <plugin>robotiq_hande_driver/RobotiqHandeHardwareInterface</plugin>
           <param name="grip_pos_min">${grip_pos_min}</param>
           <param name="grip_pos_max">${grip_pos_max}</param>
+          
           <param name="tty_port">${tty_port}</param>
           <param name="baudrate">${baudrate}</param>
           <param name="parity">${parity}</param>
@@ -18,9 +19,11 @@
           <param name="stop_bit">${stop_bit}</param>
           <param name="slave_id">${slave_id}</param>
           <param name="frequency_hz">${frequency_hz}</param>
-          <param name="virtual_tty">true</param>
-          <param name="ip_adress">aegis_ur</param>
-          <param name="port">54321</param>
+
+          <param name="create_socat_tty">${create_socat_tty}</param>
+          <param name="ip_adress">${ip_adress}</param>
+          <param name="port">${port}</param>
+          
         </xacro:unless>
       </hardware>
 

--- a/urdf/robotiq_hande_gripper.ros2_control.xacro
+++ b/urdf/robotiq_hande_gripper.ros2_control.xacro
@@ -2,7 +2,7 @@
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
   <xacro:macro
     name="robotiq_hande_ros2_control"
-    params="name prefix grip_pos_min grip_pos_max tty_port baudrate parity data_bits stop_bit slave_id frequency_hz create_socat_tty ip_adress port use_fake_hardware"
+    params="name prefix grip_pos_min grip_pos_max tty_port baudrate parity data_bits stop_bit slave_id frequency_hz create_socat_tty ip_address port use_fake_hardware"
   >
     <ros2_control name="${name}" type="system">
       <hardware>
@@ -24,7 +24,7 @@
           <param name="frequency_hz">${frequency_hz}</param>
 
           <param name="create_socat_tty">${create_socat_tty}</param>
-          <param name="ip_adress">${ip_adress}</param>
+          <param name="ip_address">${ip_address}</param>
           <param name="port">${port}</param>
         </xacro:unless>
       </hardware>

--- a/urdf/robotiq_hande_gripper.ros2_control.xacro
+++ b/urdf/robotiq_hande_gripper.ros2_control.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <xacro:macro name="robotiq_hande_ros2_control" params="name prefix grip_pos_min grip_pos_max tty baudrate parity data_bits stop_bit slave_id use_fake_hardware">
+  <xacro:macro name="robotiq_hande_ros2_control" params="name prefix grip_pos_min grip_pos_max tty baudrate parity data_bits stop_bit slave_id frequency_hz use_fake_hardware">
     <ros2_control name="${name}" type="system">
       <hardware>
         <xacro:if value="${use_fake_hardware}">
@@ -17,6 +17,7 @@
           <param name="data_bits">${data_bits}</param>
           <param name="stop_bit">${stop_bit}</param>
           <param name="slave_id">${slave_id}</param>
+          <param name="frequency_hz">${frequency_hz}</param>
         </xacro:unless>
       </hardware>
 

--- a/urdf/robotiq_hande_gripper.ros2_control.xacro
+++ b/urdf/robotiq_hande_gripper.ros2_control.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <xacro:macro name="robotiq_hande_ros2_control" params="name prefix grip_pos_min grip_pos_max tty baudrate parity data_bits stop_bit slave_id frequency_hz use_fake_hardware">
+  <xacro:macro name="robotiq_hande_ros2_control" params="name prefix grip_pos_min grip_pos_max tty_port baudrate parity data_bits stop_bit slave_id frequency_hz use_fake_hardware">
     <ros2_control name="${name}" type="system">
       <hardware>
         <xacro:if value="${use_fake_hardware}">
@@ -11,7 +11,7 @@
           <plugin>robotiq_hande_driver/RobotiqHandeHardwareInterface</plugin>
           <param name="grip_pos_min">${grip_pos_min}</param>
           <param name="grip_pos_max">${grip_pos_max}</param>
-          <param name="tty">${tty}</param>
+          <param name="tty_port">${tty_port}</param>
           <param name="baudrate">${baudrate}</param>
           <param name="parity">${parity}</param>
           <param name="data_bits">${data_bits}</param>

--- a/urdf/robotiq_hande_gripper.ros2_control.xacro
+++ b/urdf/robotiq_hande_gripper.ros2_control.xacro
@@ -18,6 +18,9 @@
           <param name="stop_bit">${stop_bit}</param>
           <param name="slave_id">${slave_id}</param>
           <param name="frequency_hz">${frequency_hz}</param>
+          <param name="virtual_tty">true</param>
+          <param name="ip_adress">aegis_ur</param>
+          <param name="port">54321</param>
         </xacro:unless>
       </hardware>
 

--- a/urdf/robotiq_hande_gripper.ros2_control.xacro
+++ b/urdf/robotiq_hande_gripper.ros2_control.xacro
@@ -1,6 +1,9 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <xacro:macro name="robotiq_hande_ros2_control" params="name prefix grip_pos_min grip_pos_max tty_port baudrate parity data_bits stop_bit slave_id frequency_hz create_socat_tty ip_adress port use_fake_hardware">
+  <xacro:macro
+    name="robotiq_hande_ros2_control"
+    params="name prefix grip_pos_min grip_pos_max tty_port baudrate parity data_bits stop_bit slave_id frequency_hz create_socat_tty ip_adress port use_fake_hardware"
+  >
     <ros2_control name="${name}" type="system">
       <hardware>
         <xacro:if value="${use_fake_hardware}">
@@ -11,7 +14,7 @@
           <plugin>robotiq_hande_driver/RobotiqHandeHardwareInterface</plugin>
           <param name="grip_pos_min">${grip_pos_min}</param>
           <param name="grip_pos_max">${grip_pos_max}</param>
-          
+
           <param name="tty_port">${tty_port}</param>
           <param name="baudrate">${baudrate}</param>
           <param name="parity">${parity}</param>
@@ -23,7 +26,6 @@
           <param name="create_socat_tty">${create_socat_tty}</param>
           <param name="ip_adress">${ip_adress}</param>
           <param name="port">${port}</param>
-          
         </xacro:unless>
       </hardware>
 

--- a/urdf/robotiq_hande_gripper.urdf.xacro
+++ b/urdf/robotiq_hande_gripper.urdf.xacro
@@ -10,6 +10,11 @@
   <xacro:arg name="stop_bit" default="1"/>
   <xacro:arg name="slave_id" default="9"/>
   <xacro:arg name="frequency_hz" default="10"/>
+
+  <xacro:arg name="create_socat_tty" default="false"/>
+  <xacro:arg name="ip_adress" default="192.168.100.10"/>
+  <xacro:arg name="port" default="54321"/>
+
   <xacro:arg name="use_fake_hardware" default="true"/>
 
   <xacro:include filename="$(find robotiq_hande_description)/urdf/robotiq_hande_gripper.xacro"/>
@@ -28,6 +33,9 @@
     stop_bit="$(arg stop_bit)"
     slave_id="$(arg slave_id)"
     frequency_hz="$(arg frequency_hz)"
+    create_socat_tty="$(arg create_socat_tty)"
+    ip_adress="$(arg ip_adress)"
+    port="$(arg port)"
     use_fake_hardware="$(arg use_fake_hardware)"
   />
 </robot>

--- a/urdf/robotiq_hande_gripper.urdf.xacro
+++ b/urdf/robotiq_hande_gripper.urdf.xacro
@@ -3,7 +3,7 @@
   <xacro:arg name="parent" default="tool0"/>
   <xacro:arg name="grip_pos_min" default="0"/>
   <xacro:arg name="grip_pos_max" default="0.025"/>
-  <xacro:arg name="tty" default="/tmp/ttyUR"/>
+  <xacro:arg name="tty_port" default="/tmp/ttyUR"/>
   <xacro:arg name="baudrate" default="115200"/>
   <xacro:arg name="parity" default="N"/>
   <xacro:arg name="data_bits" default="8"/>
@@ -21,7 +21,7 @@
     parent="$(arg parent)"
     grip_pos_min="$(arg grip_pos_min)"
     grip_pos_max="$(arg grip_pos_max)"
-    tty="$(arg tty)"
+    tty_port="$(arg tty_port)"
     baudrate="$(arg baudrate)"
     parity="$(arg parity)"
     data_bits="$(arg data_bits)"

--- a/urdf/robotiq_hande_gripper.urdf.xacro
+++ b/urdf/robotiq_hande_gripper.urdf.xacro
@@ -12,7 +12,7 @@
   <xacro:arg name="frequency_hz" default="10"/>
 
   <xacro:arg name="create_socat_tty" default="false"/>
-  <xacro:arg name="ip_adress" default="192.168.100.10"/>
+  <xacro:arg name="ip_address" default="192.168.100.10"/>
   <xacro:arg name="port" default="54321"/>
 
   <xacro:arg name="use_fake_hardware" default="true"/>
@@ -34,7 +34,7 @@
     slave_id="$(arg slave_id)"
     frequency_hz="$(arg frequency_hz)"
     create_socat_tty="$(arg create_socat_tty)"
-    ip_adress="$(arg ip_adress)"
+    ip_address="$(arg ip_address)"
     port="$(arg port)"
     use_fake_hardware="$(arg use_fake_hardware)"
   />

--- a/urdf/robotiq_hande_gripper.urdf.xacro
+++ b/urdf/robotiq_hande_gripper.urdf.xacro
@@ -9,6 +9,7 @@
   <xacro:arg name="data_bits" default="8"/>
   <xacro:arg name="stop_bit" default="1"/>
   <xacro:arg name="slave_id" default="9"/>
+  <xacro:arg name="frequency_hz" default="10"/>
   <xacro:arg name="use_fake_hardware" default="true"/>
 
   <xacro:include filename="$(find robotiq_hande_description)/urdf/robotiq_hande_gripper.xacro"/>
@@ -26,6 +27,7 @@
     data_bits="$(arg data_bits)"
     stop_bit="$(arg stop_bit)"
     slave_id="$(arg slave_id)"
+    frequency_hz="$(arg frequency_hz)"
     use_fake_hardware="$(arg use_fake_hardware)"
   />
 </robot>

--- a/urdf/robotiq_hande_gripper.xacro
+++ b/urdf/robotiq_hande_gripper.xacro
@@ -21,6 +21,7 @@
             stop_bit
             slave_id
             use_fake_hardware
+            frequency_hz:=10
             coupler_mass:=0.119
             xyz:='0 0 0'
             rpy:='0 0 0'"
@@ -37,6 +38,7 @@
       data_bits="${data_bits}"
       stop_bit="${stop_bit}"
       slave_id="${slave_id}"
+      frequency_hz="${frequency_hz}"
       use_fake_hardware="${use_fake_hardware}"
     />
 

--- a/urdf/robotiq_hande_gripper.xacro
+++ b/urdf/robotiq_hande_gripper.xacro
@@ -14,7 +14,7 @@
             parent
             grip_pos_min
             grip_pos_max
-            tty
+            tty_port
             baudrate
             parity
             data_bits
@@ -32,7 +32,7 @@
       prefix="${prefix}"
       grip_pos_min="${grip_pos_min}"
       grip_pos_max="${grip_pos_max}"
-      tty="${tty}"
+      tty_port="${tty_port}"
       baudrate="${baudrate}"
       parity="${parity}"
       data_bits="${data_bits}"

--- a/urdf/robotiq_hande_gripper.xacro
+++ b/urdf/robotiq_hande_gripper.xacro
@@ -23,7 +23,7 @@
             use_fake_hardware
             frequency_hz:=10
             create_socat_tty:=false
-            ip_adress:=192.168.100.10
+            ip_address:=192.168.100.10
             port:=54321
             coupler_mass:=0.119
             xyz:='0 0 0'
@@ -43,7 +43,7 @@
       slave_id="${slave_id}"
       frequency_hz="${frequency_hz}"
       create_socat_tty="${create_socat_tty}"
-      ip_adress="${ip_adress}"
+      ip_address="${ip_address}"
       port="${port}"
       use_fake_hardware="${use_fake_hardware}"
     />

--- a/urdf/robotiq_hande_gripper.xacro
+++ b/urdf/robotiq_hande_gripper.xacro
@@ -22,6 +22,9 @@
             slave_id
             use_fake_hardware
             frequency_hz:=10
+            create_socat_tty:=false
+            ip_adress:=192.168.100.10
+            port:=54321
             coupler_mass:=0.119
             xyz:='0 0 0'
             rpy:='0 0 0'"
@@ -39,6 +42,9 @@
       stop_bit="${stop_bit}"
       slave_id="${slave_id}"
       frequency_hz="${frequency_hz}"
+      create_socat_tty="${create_socat_tty}"
+      ip_adress="${ip_adress}"
+      port="${port}"
       use_fake_hardware="${use_fake_hardware}"
     />
 


### PR DESCRIPTION
## Description
This PR fixes a typo in a variable from `ip_adress` to `ip_address`.


## Motivation and context
The typo in the `ip_address` variable was fixed in [PR #23](https://github.com/AGH-CEAI/robotiq_hande_driver/pull/27) in the [robotiq_hande_driver](https://github.com/AGH-CEAI/robotiq_hande_driver) repository. Correcting this ensures consistency and avoids potential runtime errors when specifying the IP address for TCP connections.


## How has this been tested?
No test required.


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] All TODOs in the code have been resolved or linked to a proper issue.
- [ ] Code has been (auto)formatted.
- [ ] Documentation (e.g., README, CHANGELOG, Wiki) has been updated.
- [ ] All automated checks have passed.